### PR TITLE
fix error message for validate task

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ This command has 2 options:
 
 This command allows you to validate an update that has been deployed on a device
 
-You must specify the serial number of the device in the command:
+This command has 1 mandatory option:
+- `--device` or `-d`: Used to specify the serial number of the device on which you want to validate the update
 
 ```shell
-rebar3 grisp-io validate <serial-number>
+rebar3 grisp-io validate -d SERIAL_NUMBER
 ```
 
 ---

--- a/test/rebar3_grisp_io_validate_SUITE.erl
+++ b/test/rebar3_grisp_io_validate_SUITE.erl
@@ -79,7 +79,7 @@ setup_meck_io() ->
     ok = meck:expect(rebar3_grisp_io_io, abort, 1,
                      fun(Msg) ->
                              case Msg of
-                                 "Error: The serial number of the target device is missing. Run 'rebar3 grisp-io validate <serial-number>'" ->
+                                 "Error: The serial number of the target device is missing. Specify it with -d or --device" ->
                                      error(no_serial_nb);
                                  _ ->
                                      ct:fail(Msg)


### PR DESCRIPTION
This PR fixes reintroduce the `-d` option for the validation task

The new help message is now the following one:
```
Validate an update deployed on a specific device

Example: rebar3 grisp-io validate -d 1337

Usage: rebar3 grisp-io validate [-d <device>]

  -d, --device  Specify the serial number of the device
```

The test suite has been updated and the "skip" is now only applied to the testcase that is supposed to run successfully in the waiting of a fix.

The README has also been updated accordingly 