### PR TITLE
better handling of test profile for hackney insecure option

### DIFF
--- a/src/rebar3_grisp_io_api.erl
+++ b/src/rebar3_grisp_io_api.erl
@@ -207,8 +207,9 @@ base_url(RState) ->
 
 %% @doc adds the insecure options in the current profile is test (only for dev)
 insecure_option(RState) ->
-    case rebar_state:current_profiles(RState) of
-        [default, test | _] ->
+    Profiles = rebar_state:current_profiles(RState),
+    case lists:member(test, Profiles) of
+        true ->
             [insecure];
         _ ->
             []


### PR DESCRIPTION
This PR fixes #16
Now the order used for the profile won't matter as long as the profile `test` is included (e.g, using `dev, test` and `test,dev` will be equivalent)