### PR TITLE
Remove upload --no-pack option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ a new release package. Release packages are identified by 3 elements:
 - The application name
 - The release version in SemVer fashion (by default `0.1.0`)
 
-This command has 1 optional option:
+This command has 2 options:
 - `--force` or `-f`: This option will force an overwritting of the local and remote files of a given project and release
-
+- `--refresh` or `-r`: Force software package building even if it already exists
 ---
 ### Validate
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ a new release package. Release packages are identified by 3 elements:
 - The application name
 - The release version in SemVer fashion (by default `0.1.0`)
 
-This command has 2 options:
+This command has 1 optional option:
 - `--force` or `-f`: This option will force an overwritting of the local and remote files of a given project and release
-- `--no-pack` or `-p`: With this option enabled, the command won't run internally the command `rebar3 grisp pack`
+
 ---
 ### Validate
 


### PR DESCRIPTION
While testing the latest `grisp_connect` I realized we no longer support the `--no-pack` option in `upload`

``` shell
> rebar3 as grisp-io upload --no-pack
===> Invalid option --no-pack on task upload
```

Feel free to close this PR in case that's a bug and not a feature 🥲 